### PR TITLE
Enum Werte korrigiert

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -280,7 +280,7 @@ definitions:
     type: string
     enum:
       - Dr.
-      - Prof. Dr.
+      - Prof.
       - Prof. Dr.
 
   geschlecht:


### PR DESCRIPTION
Das Enum `Titel` hatte den Wert `Prof. Dr.` doppelt, `Prof.` fehlte.

P.S.: erster Pull Request 🥳 