### PR TITLE
Liste der Titel vervollständigt

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -281,10 +281,22 @@ definitions:
   titel:
     type: string
     enum:
+      - Dipl.-Ing.
       - Dr.
+      - Dr. med.
+      - Dr. med. dent.
+      - Dr. med. vet.
+      - Dr. ing.
+      - Dr. jur.
+      - Dr. phil.
+      - Dr. rer. nat.
+      - Dr. rer. pol.
+      - Dr. Dr.
+      - Dr. h. c.
       - Prof.
       - Prof. Dr.
-
+      - Prof. Dr. med.
+      - Prof. Dr. Dr.
   geschlecht:
     type: string
     enum:


### PR DESCRIPTION
Damit müssten wir nahezu alle Titel die unsere Banken bisher verwenden wollen unterstützen. Die ganzen Ehrendoktortitel habe ich, bis auf Dr. h. c., weggelassen.

https://europace.atlassian.net/browse/BANK-29