### PR TITLE
KITT-162 #Partnerkennzeichen

### DIFF
--- a/beispiele/example-annahme-erfolgreich.md
+++ b/beispiele/example-annahme-erfolgreich.md
@@ -239,11 +239,9 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
         "produktanbieter": "BEISPIEL_BANK",
         "kreditprovisionswunsch": 0.0123,
         "vertriebsgruppe": "Beispielgruppe",
-        "partnerkennzeichen": [
-            {
-                "vermittlernummer": "5454874845"
-            }
-        ]
+        "partnerkennzeichen": {
+            "vermittlernummer": "5454874845"
+        }
     },
     "beratungsart": "AUSSER_GESCHAEFTSRAUM_VERTRAG"
 }

--- a/beispiele/example-annahme-mit-downselling.md
+++ b/beispiele/example-annahme-mit-downselling.md
@@ -239,11 +239,9 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
         "produktanbieter": "BEISPIEL_BANK",
         "kreditprovisionswunsch": 0.0123,
         "vertriebsgruppe": "Beispielgruppe",
-        "partnerkennzeichen": [
-            {
-                "vermittlernummer": "5454874845"
-            }
-        ]
+        "partnerkennzeichen": {
+            "vermittlernummer": "5454874845"
+        }
     },
     "beratungsart": "AUSSER_GESCHAEFTSRAUM_VERTRAG"
 }

--- a/beispiele/example-annahme-mit-fehlenden-daten.md
+++ b/beispiele/example-annahme-mit-fehlenden-daten.md
@@ -237,11 +237,9 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
         "produktanbieter": "BEISPIEL_BANK",
         "kreditprovisionswunsch": 0.0123,
         "vertriebsgruppe": "Beispielgruppe",
-        "partnerkennzeichen": [
-            {
-                "vermittlernummer": "5454874845"
-            }
-        ]
+        "partnerkennzeichen": {
+            "vermittlernummer": "5454874845"
+        }
     },
     "beratungsart": "AUSSER_GESCHAEFTSRAUM_VERTRAG"
 }

--- a/beispiele/example-annahme-mit-unterdeckung.md
+++ b/beispiele/example-annahme-mit-unterdeckung.md
@@ -239,11 +239,9 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
         "produktanbieter": "BEISPIEL_BANK",
         "kreditprovisionswunsch": 0.0123,
         "vertriebsgruppe": "Beispielgruppe",
-        "partnerkennzeichen": [
-            {
-                "vermittlernummer": "5454874845"
-            }
-        ]
+        "partnerkennzeichen": {
+            "vermittlernummer": "5454874845"
+        }
     },
     "beratungsart": "AUSSER_GESCHAEFTSRAUM_VERTRAG"
 }

--- a/swagger.yml
+++ b/swagger.yml
@@ -165,7 +165,7 @@ definitions:
         type: string
       partnerkennzeichen:
         description: Key-/Value-Pairs aus dem Europace-Partnermanagement. Zum Beispiel Vermittlernummern.
-        type: array
+        type: object
         items:
           $ref: '#/definitions/partnerkennzeichen'
     required:


### PR DESCRIPTION
Partnerkennzeichen ist nun eine Map, anstatt einer Liste von Maps. Diese hätten sowieso immer nur einen Eintrag, daher ist das nicht nötig.