### PR TITLE
Changes for Release 1.0.2-alpha. Contains breaking change.

### DIFF
--- a/beispiele/example-annahme-erfolgreich.md
+++ b/beispiele/example-annahme-erfolgreich.md
@@ -141,7 +141,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
                     "rueckkaufswertLebensversicherung": 741.51,
                     "immobilien": []
                 },
-                "nichtAbzuloesendeVerbindlichkeiten": {
+                "verbindlichkeiten": {
                     "ratenkredite": [
                         {
                             "id": "lkmjhuyg7-9876-gy6z-09ik-jihyf5anbhv65v",

--- a/beispiele/example-annahme-mit-downselling.md
+++ b/beispiele/example-annahme-mit-downselling.md
@@ -141,7 +141,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
                     "rueckkaufswertLebensversicherung": 741.51,
                     "immobilien": []
                 },
-                "nichtAbzuloesendeVerbindlichkeiten": {
+                "verbindlichkeiten": {
                     "ratenkredite": [
                         {
                             "id": "lkmjhuyg7-9876-gy6z-09ik-jihyf5anbhv65v",

--- a/beispiele/example-annahme-mit-fehlenden-daten.md
+++ b/beispiele/example-annahme-mit-fehlenden-daten.md
@@ -139,7 +139,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
                     "rueckkaufswertLebensversicherung": 741.51,
                     "immobilien": []
                 },
-                "nichtAbzuloesendeVerbindlichkeiten": {
+                "verbindlichkeiten": {
                     "ratenkredite": [
                         {
                             "id": "lkmjhuyg7-9876-gy6z-09ik-jihyf5anbhv65v",

--- a/beispiele/example-annahme-mit-unterdeckung.md
+++ b/beispiele/example-annahme-mit-unterdeckung.md
@@ -141,7 +141,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
                     "rueckkaufswertLebensversicherung": 741.51,
                     "immobilien": []
                 },
-                "nichtAbzuloesendeVerbindlichkeiten": {
+                "verbindlichkeiten": {
                     "ratenkredite": [
                         {
                             "id": "lkmjhuyg7-9876-gy6z-09ik-jihyf5anbhv65v",

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 1.0.1-alpha
+  version: 1.0.2-alpha
   title: KEX Market Engine API
 basePath: /v1
 schemes:
@@ -519,8 +519,8 @@ definitions:
         $ref: '#/definitions/ausgaben'
       vermoegen:
         $ref: '#/definitions/vermoegen'
-      nichtAbzuloesendeVerbindlichkeiten:
-        $ref: '#/definitions/nichtAbzuloesendeVerbindlichkeiten'
+      verbindlichkeiten:
+        $ref: '#/definitions/verbindlichkeiten'
 
   einnahmen:
     type: object
@@ -662,7 +662,7 @@ definitions:
       - EIGENGENUTZT
       - EIGENGENUTZT_UND_VERMIETET
 
-  nichtAbzuloesendeVerbindlichkeiten:
+  verbindlichkeiten:
     type: object
     properties:
       ratenkredite:

--- a/swagger.yml
+++ b/swagger.yml
@@ -645,7 +645,7 @@ definitions:
       id:
         type: string
       art:
-        type: string
+        $ref: '#/definitions/immobilienart'
       verkehrswert:
         $ref: '#/definitions/euro'
       wohnflaeche:
@@ -655,12 +655,20 @@ definitions:
       nutzungsart:
         $ref: '#/definitions/immobiliennutzungsart'
 
+  immobilienart:
+    type: string
+      enum:
+        - EIGENTUMSWOHNUNG
+        - EINFAMILIENHAUS
+        - MEHRFAMILIENHAUS
+        - BUERO_GESCHAEFTSGEBAEUDE
+
   immobiliennutzungsart:
     type: string
-    enum:
-      - VERMIETET
-      - EIGENGENUTZT
-      - EIGENGENUTZT_UND_VERMIETET
+      enum:
+        - VERMIETET
+        - EIGENGENUTZT
+        - EIGENGENUTZT_UND_VERMIETET
 
   verbindlichkeiten:
     type: object


### PR DESCRIPTION
Changeset:

KITT-188 **Breacking Change.** Field nichtAbzuloesendeVerbindlichkeiten is renamed to verbindlichkeiten because it also contains abzulösende Verbindlichkeiten.

KITT-189 Change type of immobilie.art from String to Enum because there are only 4 valid values. 

Changed version from 1.0.1-alpha to 1.0.2-alpha