### PR TITLE
Remove absolute paths from ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,20 +17,20 @@ Die API ermöglicht es Produktanbietern im Ratenkreditgeschäft, ihr Kreditangeb
 
 # Inhaltsverzeichnis
 
-* [API Version](https://github.com/europace/kex-market-engine-api#api-version)
-* [Dokumentation](https://github.com/europace/kex-market-engine-api#dokumentation)
-  * [API Spezifikation](https://github.com/europace/kex-market-engine-api#api-spezifikation)
-  * [API Referenz](https://github.com/europace/kex-market-engine-api#api-referenz)
-    * [Request](https://github.com/europace/kex-market-engine-api#request)
-    * [Response](https://github.com/europace/kex-market-engine-api#response)
-      * [Umgang mit unvollständigen Anfragen](https://github.com/europace/kex-market-engine-api#umgang-mit-unvollst%C3%A4ndigen-anfragen)
-      * [Umgang mit einer Unterdeckung in der Haushaltsrechnung](https://github.com/europace/kex-market-engine-api#umgang-mit-einer-unterdeckung-in-der-haushaltsrechnung)
-      * [Meldungskategorie](https://github.com/europace/kex-market-engine-api#meldungskategorie)
-      * [Machbarkeitsstatus](https://github.com/europace/kex-market-engine-api#machbarkeitsstatus)
-* [Authentifizierung](https://github.com/europace/kex-market-engine-api#authentifizierung)
-* [Performance](https://github.com/europace/kex-market-engine-api#performance)
-* [Beispiele](https://github.com/europace/kex-market-engine-api#beispiele)
-* [Nutzungsbedingungen](https://github.com/europace/kex-market-engine-api#nutzungsbedingungen)
+* [API Version](#api-version)
+* [Dokumentation](#dokumentation)
+  * [API Spezifikation](#api-spezifikation)
+  * [API Referenz](#api-referenz)
+    * [Request](#request)
+    * [Response](#response)
+      * [Umgang mit unvollständigen Anfragen](#umgang-mit-unvollst%C3%A4ndigen-anfragen)
+      * [Umgang mit einer Unterdeckung in der Haushaltsrechnung](#umgang-mit-einer-unterdeckung-in-der-haushaltsrechnung)
+      * [Meldungskategorie](#meldungskategorie)
+      * [Machbarkeitsstatus](#machbarkeitsstatus)
+* [Authentifizierung](#authentifizierung)
+* [Performance](#performance)
+* [Beispiele](#beispiele)
+* [Nutzungsbedingungen](#nutzungsbedingungen)
 
 ## API Version
 


### PR DESCRIPTION
Für die neue API Webseite müssen die Links in der ToC relativ sein.