### PR TITLE
Version in swagger nachgezogen

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 2.3.0
+  version: 2.3.1
   title: KEX Market Engine API
 basePath: /v1
 schemes:


### PR DESCRIPTION
Da der Release 2.3.0 bereits "verbraucht" ist nutze ich den Patch-Level um wieder einen konsistenten Stand zu erzeugen

Fürs nächste Mal: Man muss also mit der inhaltlichen Änderung bereits die Version in swagger so anpassen, dass man den Tag/Release in GitHub danach setzen kann