### PR TITLE
Description für referenznummerProduktanbieter und referenznummerDienstleister hinzugefügt

### DIFF
--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 2.4.0
+  version: 2.4.1
   title: KEX Market Engine API
 basePath: /v1
 schemes:
@@ -1050,8 +1050,10 @@ definitions:
         description: ID eines Produktanbieters, wie in der Anfrage unter handelsbeziehung.produktanbieter angegeben. Ordnet das Angebot dem angefragtem Produktanbieter zu.
         type: string
       referenznummerProduktanbieter:
+        description: Vertrags- oder Antragsnummer des Produktanbieters. Dient auch der späteren Identifiezierung des Antrags bei Statusupdates.
         type: string
       referenznummerDienstleister:
+        description: Bei Anbindunger mehrerer Produktanbieter durch einen Dienstleister zu füllen.
         type: string
       produktbezeichnung:
         type: string

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 2.4.1
+  version: 2.4.2
   title: KEX Market Engine API
 basePath: /v1
 schemes:

--- a/swagger.yml
+++ b/swagger.yml
@@ -1050,7 +1050,7 @@ definitions:
         description: ID eines Produktanbieters, wie in der Anfrage unter handelsbeziehung.produktanbieter angegeben. Ordnet das Angebot dem angefragtem Produktanbieter zu.
         type: string
       referenznummerProduktanbieter:
-        description: Vertrags- oder Antragsnummer des Produktanbieters. Dient auch der späteren Identifiezierung des Antrags bei Statusupdates.
+        description: Vertrags- oder Antragsnummer des Produktanbieters. Dient auch der späteren Identifizierung des Antrags bei Statusupdates.
         type: string
       referenznummerDienstleister:
         description: Bei Anbindunger mehrerer Produktanbieter durch einen Dienstleister zu füllen.

--- a/swagger.yml
+++ b/swagger.yml
@@ -1053,7 +1053,7 @@ definitions:
         description: Vertrags- oder Antragsnummer des Produktanbieters. Dient auch der späteren Identifizierung des Antrags bei Statusupdates.
         type: string
       referenznummerDienstleister:
-        description: Bei Anbindunger mehrerer Produktanbieter durch einen Dienstleister zu füllen.
+        description: Erfolgt die Antragserzeugung mithilfe eines Dienstleisters, wird hier die Antrags-ID des durchleitenden Dienstleisters erwartet.
         type: string
       produktbezeichnung:
         type: string


### PR DESCRIPTION
Hier bitte mal aufs Wording schauen, ob das so verständlich ist. Warum ist 'referenznummerProduktanbieter' eigentlich nicht required? 🤔 