### PR TITLE
KreditKonditionen dürfen leer bleiben, um zu signalisieren, dass keine Konditionen zur Verfügung stehen

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ supportMeldung</code>.
 
 A complete offer without document(s) is expected. The feasibility status is `NICHT_MACHBAR`. Completeness messages, that point out the missing data, must be available.
 
+If conditions of an offer are not available due to missing/incomplete response of the backend-system, the field `kredit` could be left empty (`null`). The offer will be automatically marked as `NICHT_MACHBAR`.
+
 ##### Handling shortfall in the Haushaltsrechnung
 
 If the application is not feasible due to a shortfall in the Haushaltsrechnung, ideally the duration will be extended. If this is not possible, a downselling of the loan amount can take place.

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 2.4.4
+  version: 2.4.5
   title: KEX Market Engine API
 basePath: /v1
 schemes:

--- a/swagger.yml
+++ b/swagger.yml
@@ -1073,6 +1073,7 @@ definitions:
         description: Token, dass dazu dient die bei der Ermittlung berechnete AngebotsVariante bei der Annahme identifizieren zu können.
         type: string
       kredit:
+        description: Angaben zu den Kredit-Konditionen. Wenn diese fehlen (null) wird das Angebot als NICHT-MACHBAR interpretiert.
         $ref: '#/definitions/kredit'
       status:
         $ref: '#/definitions/angebotsstatus'
@@ -1097,7 +1098,6 @@ definitions:
       - produktbezeichnung
       - produktart
       - angebotsvariantentyp
-      - kredit
       - status
 
   produktart:


### PR DESCRIPTION
KITT-1990