### PR TITLE
KITT-2988: Remove several, obsolete fields

### DIFF
--- a/beispiele/example-annahme-erfolgreich.md
+++ b/beispiele/example-annahme-erfolgreich.md
@@ -138,7 +138,6 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
           "sonstigeAusgaben": 65
         },
         "vermoegen": {
-          "rueckkaufswertLebensversicherung": 741.51,
           "immobilien": []
         },
         "verbindlichkeiten": {
@@ -164,9 +163,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
               "glaeubiger": "MUSTERBANK"
             }
           ],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -194,8 +191,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {},
     "modernisierung": {}

--- a/beispiele/example-annahme-mit-downselling.md
+++ b/beispiele/example-annahme-mit-downselling.md
@@ -138,7 +138,6 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
           "sonstigeAusgaben": 65
         },
         "vermoegen": {
-          "rueckkaufswertLebensversicherung": 741.51,
           "immobilien": []
         },
         "verbindlichkeiten": {
@@ -164,9 +163,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
               "glaeubiger": "MUSTERBANK"
             }
           ],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -194,8 +191,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {},
     "modernisierung": {}

--- a/beispiele/example-annahme-mit-fehlenden-daten.md
+++ b/beispiele/example-annahme-mit-fehlenden-daten.md
@@ -136,7 +136,6 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
           "sonstigeAusgaben": 65
         },
         "vermoegen": {
-          "rueckkaufswertLebensversicherung": 741.51,
           "immobilien": []
         },
         "verbindlichkeiten": {
@@ -162,9 +161,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
               "glaeubiger": "MUSTERBANK"
             }
           ],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -192,8 +189,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {}
   },

--- a/beispiele/example-annahme-mit-kontoumsaetzen.md
+++ b/beispiele/example-annahme-mit-kontoumsaetzen.md
@@ -146,7 +146,6 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
           "sonstigeAusgaben": 65
         },
         "vermoegen": {
-          "rueckkaufswertLebensversicherung": 741.51,
           "immobilien": []
         },
         "verbindlichkeiten": {
@@ -172,9 +171,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
               "glaeubiger": "MUSTERBANK"
             }
           ],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -202,8 +199,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {},
     "modernisierung": {}

--- a/beispiele/example-annahme-mit-unterdeckung.md
+++ b/beispiele/example-annahme-mit-unterdeckung.md
@@ -138,7 +138,6 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
           "sonstigeAusgaben": 65
         },
         "vermoegen": {
-          "rueckkaufswertLebensversicherung": 741.51,
           "immobilien": []
         },
         "verbindlichkeiten": {
@@ -164,9 +163,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
               "glaeubiger": "MUSTERBANK"
             }
           ],
-          "immobiliendarlehen": [],
-          "geschaeftskredite": [],
-          "kontokorrentkredite": []
+          "immobiliendarlehen": []
         }
       }
     }
@@ -194,8 +191,7 @@ Es handelt sich um ein Beispiel zum besseren Verständnis der API.
       "ratenkredite": [],
       "sonstigeVerbindlichkeiten": [],
       "kreditkarten": [],
-      "dispositionskredite": [],
-      "geschaeftskredite": []
+      "dispositionskredite": []
     },
     "fahrzeug": {},
     "modernisierung": {}

--- a/swagger.yml
+++ b/swagger.yml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 2.6.0
+  version: 3.0.0
   title: KEX Market Engine API
 basePath: /v1
 schemes:

--- a/swagger.yml
+++ b/swagger.yml
@@ -601,8 +601,6 @@ definitions:
           $ref: '#/definitions/nebentaetigkeit'
       mietUndPachteinnahmen:
         $ref: '#/definitions/mietUndPachteinnahmen'
-      einkuenfteAusKapitalvermoegen:
-        $ref: '#/definitions/euro'
       sonstigeEinnahmen:
         $ref: '#/definitions/euro'
 
@@ -676,20 +674,10 @@ definitions:
   vermoegen:
     type: object
     properties:
-      rueckkaufswertLebensversicherung:
-        $ref: '#/definitions/euro'
-      bausparguthaben:
-        $ref: '#/definitions/euro'
       immobilien:
         type: array
         items:
           $ref: '#/definitions/immobilie'
-      depotguthaben:
-        $ref: '#/definitions/euro'
-      bankUndSparguthaben:
-        $ref: '#/definitions/euro'
-      sonstigesVermoegen:
-        $ref: '#/definitions/euro'
 
   immobilie:
     type: object
@@ -751,14 +739,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/immobiliendarlehen'
-      geschaeftskredite:
-        type: array
-        items:
-          $ref: '#/definitions/geschaeftskredit'
-      kontokorrentkredite:
-        type: array
-        items:
-          $ref: '#/definitions/kontokorrentkredit'
 
   ratenkredit:
     type: object
@@ -849,37 +829,6 @@ definitions:
       restschuld:
         $ref: '#/definitions/euro'
 
-  geschaeftskredit:
-    type: object
-    properties:
-      id:
-        type: string
-      monatlicheRate:
-        $ref: '#/definitions/euro'
-      letzteRate:
-        $ref: '#/definitions/euro'
-      datumLetzteRate:
-        type: string
-        format: date
-      restschuld:
-        $ref: '#/definitions/euro'
-      glaeubiger:
-        type: string
-
-  kontokorrentkredit:
-    type: object
-    properties:
-      id:
-        type: string
-      verfuegungsrahmen:
-        $ref: '#/definitions/euro'
-      beanspruchterBetrag:
-        $ref: '#/definitions/euro'
-      zinssatz:
-        $ref: '#/definitions/prozent'
-      glaeubiger:
-        type: string
-
   ###
   ### Finanzierungswunsch
   ###
@@ -942,10 +891,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/abzuloesenderDispositionskredit'
-      geschaeftskredite:
-        type: array
-        items:
-          $ref: '#/definitions/abzuloesenderGeschaeftskredit'
 
   finanzierungszweck:
     description: Verwendungszweck
@@ -1008,21 +953,6 @@ definitions:
     properties:
       id:
         type: string
-      abloeseBetrag:
-        $ref: '#/definitions/euro'
-      konto:
-        $ref: '#/definitions/konto'
-
-  abzuloesenderGeschaeftskredit:
-    type: object
-    properties:
-      id:
-        type: string
-      datumErsteRate:
-        type: string
-        format: date
-      urspruenglicherBetrag:
-        $ref: '#/definitions/euro'
       abloeseBetrag:
         $ref: '#/definitions/euro'
       konto:


### PR DESCRIPTION
Nach Abstimmung mit den Banken können folgende Felder ersatzlos entfernt werden:
- `rueckkaufswertLebensversicherung`
- `bausparguthaben`
- `depotguthaben`
- `bankUndSparguthaben`
- `sonstigesVermoegen`
- `einkuenfteAusKapitalvermoegen` 
- `geschaeftskredite`
- `kontokorrentkredite`

Nach Rückfrage betrifft `geschaeftskredite` die Verbindlichkeiten, als auch die abzulösenden Verbindlichkeiten.